### PR TITLE
Add standalone deployment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# lunabot #
+# lunabot
 
-## Build & Run ##
+## Build & Run
 
 ```sh
 $ cd lunabot
@@ -9,4 +9,16 @@ $ ./sbt
 > browse
 ```
 
+
 If `browse` doesn't launch your browser, manually open [http://localhost:8080/](http://localhost:8080/) in your browser.
+
+
+## Standalone Deployment
+
+
+```sh
+sbt clean assembly
+java -jar target/scala-2.11/lunabot-assembly-0.1.0-SNAPSHOT.jar
+```
+
+You can copy the generated assembly jar and run it on the server.

--- a/project/assembly.sbt
+++ b/project/assembly.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.0")

--- a/project/build.scala
+++ b/project/build.scala
@@ -27,7 +27,7 @@ object LunabotBuild extends Build {
         "org.scalatra" %% "scalatra-scalate" % ScalatraVersion,
         "org.scalatra" %% "scalatra-specs2" % ScalatraVersion % "test",
         "ch.qos.logback" % "logback-classic" % "1.1.2" % "runtime",
-        "org.eclipse.jetty" % "jetty-webapp" % "9.2.10.v20150310" % "container",
+        "org.eclipse.jetty" % "jetty-webapp" % "9.2.10.v20150310" % "container;compile",
         "javax.servlet" % "javax.servlet-api" % "3.1.0" % "provided"
       ),
       scalateTemplateConfig in Compile <<= (sourceDirectory in Compile){ base =>

--- a/src/main/scala/com/lunatech/lunabot/JettyLauncher.scala
+++ b/src/main/scala/com/lunatech/lunabot/JettyLauncher.scala
@@ -1,0 +1,26 @@
+package com.lunatech.lunabot
+import org.eclipse.jetty.server.Server
+import org.eclipse.jetty.servlet.DefaultServlet
+import org.eclipse.jetty.webapp.WebAppContext
+import org.scalatra.servlet.ScalatraListener
+
+
+object JettyLauncher {
+
+  def main(args: Array[String]) {
+    val port = if(System.getenv("PORT") != null) System.getenv("PORT").toInt else 8080
+
+    val server = new Server(port)
+    val context = new WebAppContext()
+
+    context setContextPath "/"
+    context.setResourceBase("src/main/webapp")
+    context.addEventListener(new ScalatraListener)
+    context.addServlet(classOf[DefaultServlet], "/")
+
+    server.setHandler(context)
+    server.start
+    server.join
+
+  }
+}


### PR DESCRIPTION
We can run the application either "standalone" with Jetty server or
deploy it into a container. The first option needs a bit of
configuration and a plugin to prepare the jar. That's what this commit
is adding.
